### PR TITLE
fixes "UnboundLocalError" point_exponent variable

### DIFF
--- a/ecc_analysis.py
+++ b/ecc_analysis.py
@@ -119,7 +119,7 @@ def is_point_odd(point):
 
     scalar = CURVE_MAX - 2
 
-    point_exponent = point_exponent(point, scalar)
+    result = point_exponent(point, scalar)
     modulo_2_result = point_multiplication(point, point_exponent)
 
     if modulo_2_result == get_first_point():


### PR DESCRIPTION
Fixes the error "UnboundLocalError: cannot access local variable 'point_exponent' where it is not associated with a value" that occurs due to the name of the function being used as a variable in the function itself.